### PR TITLE
fixed group id and nexus release plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
         xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.arrahtech</groupId>
+    <groupId>org.arrahtec</groupId>
     <artifactId>osdq-core</artifactId>
     <version>6.2.9</version>
     <name>osdq-core</name>
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.3</version>
+                <version>1.6.7</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>


### PR DESCRIPTION
it seems we updated the group id got changed to arrahtech instead of arrahtec, that we originally registered in maven central. Due to this we were unable to push our jars to maven. More details about the issue https://issues.sonatype.org/browse/OSSRH-54894. 

This PR changes the group id back to arrahtec