### PR TITLE
Support Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,12 @@
                     <version>3.2</version>
                     <configuration>
                         <!-- put your configurations here -->
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>11</source>
+                        <target>11</target>
+                        <compilerArgs>
+                            <arg>--add-exports</arg>
+                            <arg>java.sql.rowset/com.sun.rowset=ALL-UNNAMED</arg>
+                        </compilerArgs>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
moving to java 11.

UpdatableJdbcRowsetImpl.java depends on com.sun.rowset.JdbcRowSetResourceBundle; which is now considered internal API post Java 9 and oracle doesn't want us to use it. I have temporarily bypassed the check through --add-export argument. Going forward we should move away from this completely. 